### PR TITLE
enabling library being usable with JDK11

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>17</java.version>
+        <java.version>11</java.version>
         <bouncy.castle.version>1.81</bouncy.castle.version>
     </properties>
 

--- a/core/src/main/java/in/neuw/aws/rolesanywhere/utils/CertAndKeyParserAndLoader.java
+++ b/core/src/main/java/in/neuw/aws/rolesanywhere/utils/CertAndKeyParserAndLoader.java
@@ -414,12 +414,14 @@ public class CertAndKeyParserAndLoader {
         PrivateKeyInfo privateKeyInfo;
         String originalFormat;
 
-        if (inputPemObject instanceof PEMKeyPair keyPair) {
+        if (inputPemObject instanceof PEMKeyPair) {
+            final var keyPair = (PEMKeyPair) inputPemObject;
             // Handle PKCS#1 format (RSA PRIVATE KEY, EC PRIVATE KEY, etc.)
             originalFormat = "PKCS#1";
             privateKeyInfo = keyPair.getPrivateKeyInfo();
             log.info("Private key Input format: PKCS#1 (Traditional format)");
-        } else if (inputPemObject instanceof PrivateKeyInfo instancePrivateKeyInfo) {
+        } else if (inputPemObject instanceof PrivateKeyInfo) {
+            final var instancePrivateKeyInfo = (PrivateKeyInfo) inputPemObject;
             // Handle PKCS#8 format (PRIVATE KEY)
             originalFormat = "PKCS#8";
             privateKeyInfo = instancePrivateKeyInfo;

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <java.version>17</java.version>
     <parent.version>${project.version}</parent.version>
     <jackson-bom.version>2.20.0</jackson-bom.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <jacoco.version>0.8.10</jacoco.version>
     <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>


### PR DESCRIPTION
I would be very happy if you can accept this trivial change to make the whole library also available for java11 JVMs.
I know that these are out-dated, but still somewhere no newer JRE is available.

Believing in the open-source idea, I would prefer this small change as contribution to all your work (instead of establishing a world of forks with trivial changes)

Thank you!